### PR TITLE
#1 Updated the Prism version number so that npm install would run.

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.8.8",
-    "prism": "^5.7.0",
+    "prism": "^4.1.2",
     "typescript": "^5.1.6",
     "vite": "^4.3.9"
   }


### PR DESCRIPTION
Here is a super tiny fix to resolve what appears to be an incorrect version number for the prism package.